### PR TITLE
responseパッケージにてユーザに返すJSONを構造体として定義

### DIFF
--- a/controller/response/user.go
+++ b/controller/response/user.go
@@ -1,0 +1,18 @@
+package response
+
+type UserResponse struct {
+	UserID string `json:"user_id"`
+	Name   string `json:"name"`
+}
+
+type GetUserResponse struct {
+	Name string `json:"name"`
+}
+
+type CreateUserResponse struct {
+	Token string `json:"token"`
+}
+
+type GetAllUserRespponse struct {
+	Users []UserResponse `json:"users"`
+}

--- a/controller/user/user.go
+++ b/controller/user/user.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"CATechDojo/controller/request"
+	"CATechDojo/controller/response"
 	"CATechDojo/model/user"
 	"bytes"
 	"encoding/json"
@@ -23,7 +24,16 @@ func GetAll(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
 
-	data, err := json.Marshal(users)
+	var userSlice response.GetAllUserRespponse
+	for _, userdata := range users {
+		res := response.UserResponse{
+			UserID: userdata.UserID,
+			Name:   userdata.Name,
+		}
+		userSlice.Users = append(userSlice.Users, res)
+	}
+
+	data, err := json.Marshal(userSlice)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
@@ -48,7 +58,11 @@ func GetUser(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
 
-	data, err := json.Marshal(u)
+	res := response.GetUserResponse{
+		Name: u.GetName(),
+	}
+
+	data, err := json.Marshal(res)
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -92,9 +106,12 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "ユーザデータを保存できませんでした", http.StatusInternalServerError)
 	}
 
+	var res response.CreateUserResponse
+	res.Token = reqBody.AuthToken
+
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
-	data, err := json.Marshal(reqBody)
+	data, err := json.Marshal(res)
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/main.go
+++ b/main.go
@@ -14,9 +14,9 @@ func main() {
 
 	//MethodsメソッドでHTTPメソッドの種類を指定
 	r.HandleFunc("/health", health.HealthCheck).Methods("GET")
-  r.HandleFunc("/user", user.GetAll).Methods("GET")
+	r.HandleFunc("/user", user.GetAll).Methods("GET")
 	r.HandleFunc("/user/get", user.GetUser).Methods("GET")
-  r.HandleFunc("/user/create", user.Create).Methods("POST")
+	r.HandleFunc("/user/create", user.Create).Methods("POST")
 	r.HandleFunc("/user/update", user.ChangeName).Methods("PUT")
 
 	http.ListenAndServe(":8080", r)

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -7,9 +7,10 @@ import (
 //インターフェースを定義
 type userInterface interface {
 	SelectAll() ([]UserData, error)
-  SelectUser(string) error
+	SelectUser(string) error
 	Insert() error
 	UpdateName(token string) error
+	GetName() string
 }
 
 //定義したインターフェースを満たすインスタンスを生成する関数を定義
@@ -18,6 +19,10 @@ func New() userInterface {
 }
 
 //インスタンスが持つ関数（メソッド）を定義
+func (u *UserData) GetName() string {
+	return u.Name
+}
+
 func (u *UserData) SelectAll() ([]UserData, error) {
 	rows, err := db.DBInstance.Query("SELECT * FROM user")
 	if err != nil {
@@ -34,7 +39,6 @@ func (u *UserData) SelectAll() ([]UserData, error) {
 	}
 	return userSlice, nil
 }
-
 
 func (u *UserData) SelectUser(token string) error {
 	row := db.DBInstance.QueryRow("SELECT * FROM user WHERE auth_token = ?", token)


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよいです -->

## Issue15
<!-- 対象のIssue -->
close #15 

## タスク整理
<!-- 自分自身のタスク整理に使ってください。 -->
- [x] responseパッケージの作成
- [x] ユーザに返すJSONを構造体として定義
- [x] 処理後のデータを定義した構造体へマッピングする

## 学んだこと
<!-- 学んだことのメモや参考にしたサイトのリンクを集めておく場所としてご利用ください -->

- アクセサメソッド（get/setメソッド）：インターフェース型のインスタンスは構造体ではないので、外部からフィールドに直接アクセスできない。そのため、アクセサメソッドを定義しすることで、フィールドの値の取得や代入を行うことができるようにする。

- JSONでは、ブロック（{}）の中に`json:"<キー>"`で指定したキーとバリューを格納している。
変換する値に対して直接キーをつけることはできない。
```
//OK
{
  "name": "string"
}

//Error
"name": "string"
```


## 補足事項
<!-- レビュー時に注意してほしいことなどを書いてください -->
